### PR TITLE
Fix bug which default label is gone

### DIFF
--- a/src/ValueValidator.php
+++ b/src/ValueValidator.php
@@ -92,6 +92,11 @@ class ValueValidator
      */
     public function add($name, $options = null, $messageTemplate = null, $label = null)
     {
+        // set the default label
+        if ($label !== null && $this->label === null) {
+            $this->label = $label;
+        }
+
         if (is_array($name) && !is_callable($name)) {
             return $this->addMultiple($name);
         }

--- a/tests/src/ValidatorTest.php
+++ b/tests/src/ValidatorTest.php
@@ -154,6 +154,24 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('This input must be a valid email address'), $this->validator->getMessages('itemc'));
     }
 
+        function testAddingValidationRulesViaStringsWithoutLabelArg()
+    {
+        $this->validator
+            // mixed rules in 1 string
+            ->add('item:Item', 'required | minLength({"min":4})')
+            // validator options as a QUERY string
+            ->add('itema:Item', 'minLength', 'min=8')
+            // validator without options and custom message
+            ->add('itemb:Item B', 'required')
+            // validator with defaults
+            ->add('itemc', 'email');
+        $this->validator->validate(array('item' => 'ab', 'itema' => 'abc', 'itemc' => 'abc'));
+        $this->assertEquals(array('Item should have at least 4 characters'), $this->validator->getMessages('item'));
+        $this->assertEquals(array('Item should have at least 8 characters'), $this->validator->getMessages('itema'));
+        $this->assertEquals(array('Item B is required'), $this->validator->getMessages('itemb'));
+        $this->assertEquals(array('This input must be a valid email address'), $this->validator->getMessages('itemc'));
+    }
+
     function testExceptionOnInvalidValidatorOptions()
     {
         $this->setExpectedException('\InvalidArgumentException');


### PR DESCRIPTION
When I set like below, default label is gone from error message.

~~~
$validator->add('itemb:Item B', 'required');
~~~
