### PR TITLE
Add AbstractRule::getOption()

### DIFF
--- a/src/Rule/AbstractRule.php
+++ b/src/Rule/AbstractRule.php
@@ -203,6 +203,21 @@ abstract class AbstractRule
     }
 
     /**
+     * Get an option for the validator.
+     * 
+     * @param string $name
+     * @return mixed
+     */
+    public function getOption($name)
+    {
+        if (isset($this->options[$name])) {
+            return $this->options[$name];
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * The context of the validator can be used when the validator depends on other values
      * that are not known at the moment the validator is constructed
      * For example, when you need to validate an email field matches another email field,

--- a/tests/src/Rule/AbstractValidatorTest.php
+++ b/tests/src/Rule/AbstractValidatorTest.php
@@ -65,4 +65,11 @@ class AbstractRuleTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\InvalidArgumentException');
         $this->rule->setContext(new \stdClass());
     }
+
+    function testGetOption()
+    {
+        $this->rule->setOption('label', 'Accept');
+        $this->assertEquals('Accept', $this->rule->getOption('label'));
+        $this->assertNull($this->rule->getOption('notExist'));
+    }
 }


### PR DESCRIPTION
I want to add *fatal* rule that stops application.

For example, if I validate data on client side, normal users never send invalid data.
If invalid data comes, it must be an attack. 

There is no reason to continue processing for attackers. So if a *fatal* rule fails,
I want to stop application immediately.

If there is `getOption()`, I can implement like this.

Set a fatal rule (`'fatal' => true`):
~~~php
$validator->add('field', 'maxlength', ['max' => 3, 'fatal' => true]);
~~~

Check fatal rule:
~~~php
if ($rule->getOption('fatal')) {
    throw RuntimeException($rule->getMessage());
}
~~~
