### PR TITLE
Fixed the autoload call causing issues with Magento Varien Autoloader

### DIFF
--- a/src/RuleFactory.php
+++ b/src/RuleFactory.php
@@ -215,7 +215,7 @@ class RuleFactory
                 $name = $this->validatorsMap[strtolower($name)];
             }
             // try if the validator is the name of a class in the package
-            if (class_exists('\Sirius\Validation\Rule\\' . $name)) {
+            if (class_exists('\Sirius\Validation\Rule\\' . $name, false)) {
                 $name = '\Sirius\Validation\Rule\\' . $name;
             }
             // at this point we should have a class that can be instanciated


### PR DESCRIPTION
Had issues with autoloaders intercepting the class_exists call and failing, added the false flag to prevent them being kicked off alongside Composer

Reference
http://php.net/manual/en/function.class-exists.php
http://php.net/manual/en/function.spl-autoload-call.php