### PR TITLE
Added require upload, and corrected upload rule behaviour

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": ">=5.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "3.7"
+    "phpunit/phpunit": "^3.7"
   },
   "autoload": {
     "psr-4": {

--- a/src/Rule/Upload/Extension.php
+++ b/src/Rule/Upload/Extension.php
@@ -32,8 +32,14 @@ class Extension extends AbstractRule
     public function validate($value, $valueIdentifier = null)
     {
         $this->value = $value;
-        if (! is_array($value) || ! isset($value['tmp_name']) || ! file_exists($value['tmp_name'])) {
+        if (! is_array($value) || ! isset($value['tmp_name'])) {
             $this->success = false;
+        } else if(! file_exists($value['tmp_name'])) {
+            if($value['error'] === UPLOAD_ERR_NO_FILE ){
+                $this->success = true;
+            }else{
+                $this->success = false;
+            }
         } else {
             $extension     = strtolower(substr($value['name'], strrpos($value['name'], '.') + 1, 10));
             $this->success = is_array($this->options[self::OPTION_ALLOWED_EXTENSIONS]) && in_array(

--- a/src/Rule/Upload/Image.php
+++ b/src/Rule/Upload/Image.php
@@ -42,8 +42,14 @@ class Image extends AbstractRule
     public function validate($value, $valueIdentifier = null)
     {
         $this->value = $value;
-        if (! is_array($value) || ! isset($value['tmp_name']) || ! file_exists($value['tmp_name'])) {
+        if (! is_array($value) || ! isset($value['tmp_name'])) {
             $this->success = false;
+        } else if(! file_exists($value['tmp_name'])) {
+            if($value['error'] === UPLOAD_ERR_NO_FILE ){
+                $this->success = true;
+            }else{
+                $this->success = false;
+            }
         } else {
             $imageInfo     = getimagesize($value['tmp_name']);
             $extension     = isset($this->imageTypesMap[$imageInfo[2]]) ? $this->imageTypesMap[$imageInfo[2]] : false;

--- a/src/Rule/Upload/ImageHeight.php
+++ b/src/Rule/Upload/ImageHeight.php
@@ -20,8 +20,14 @@ class ImageHeight extends AbstractRule
     public function validate($value, $valueIdentifier = null)
     {
         $this->value = $value;
-        if (!is_array($value) || !isset($value['tmp_name']) || !file_exists($value['tmp_name'])) {
+        if (! is_array($value) || ! isset($value['tmp_name'])) {
             $this->success = false;
+        } else if(! file_exists($value['tmp_name'])) {
+            if($value['error'] === UPLOAD_ERR_NO_FILE ){
+                $this->success = true;
+            }else{
+                $this->success = false;
+            }
         } else {
             $imageInfo     = getimagesize($value['tmp_name']);
             $height        = isset($imageInfo[1]) ? $imageInfo[1] : 0;

--- a/src/Rule/Upload/ImageRatio.php
+++ b/src/Rule/Upload/ImageRatio.php
@@ -38,9 +38,15 @@ class ImageRatio extends AbstractRule
     {
         $this->value = $value;
         $ratio       = $this->normalizeRatio($this->options[self::OPTION_RATIO]);
-        if (! is_array($value) || ! isset($value['tmp_name']) || ! file_exists($value['tmp_name'])) {
+        if (! is_array($value) || ! isset($value['tmp_name'])) {
             $this->success = false;
-        } elseif ($ratio == 0) {
+        } else if(! file_exists($value['tmp_name'])) {
+            if($value['error'] === UPLOAD_ERR_NO_FILE ){
+                $this->success = true;
+            }else{
+                $this->success = false;
+            }
+        } else if ($ratio == 0) {
             $this->success = true;
         } else {
             $imageInfo     = getimagesize($value['tmp_name']);

--- a/src/Rule/Upload/ImageWidth.php
+++ b/src/Rule/Upload/ImageWidth.php
@@ -20,8 +20,14 @@ class ImageWidth extends AbstractRule
     public function validate($value, $valueIdentifier = null)
     {
         $this->value = $value;
-        if (!is_array($value) || !isset($value['tmp_name']) || !file_exists($value['tmp_name'])) {
+        if (! is_array($value) || ! isset($value['tmp_name'])) {
             $this->success = false;
+        } else if(! file_exists($value['tmp_name'])) {
+            if($value['error'] === UPLOAD_ERR_NO_FILE ){
+                $this->success = true;
+            }else{
+                $this->success = false;
+            }
         } else {
             $imageInfo     = getimagesize($value['tmp_name']);
             $width         = isset($imageInfo[0]) ? $imageInfo[0] : 0;

--- a/src/Rule/Upload/Required.php
+++ b/src/Rule/Upload/Required.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Gumacs
+ * Date: 2017. 03. 07.
+ * Time: 16:02
+ */
+
+namespace Sirius\Validation\Rule\Upload;
+
+
+use Sirius\Validation\Rule\AbstractRule;
+
+class Required extends AbstractRule
+{
+    const MESSAGE = 'The file is required';
+
+    const LABELED_MESSAGE = '{label} is required';
+
+    public function validate($value, $valueIdentifier = null)
+    {
+        $this->value = $value;
+        if (! is_array($value) || ! isset($value['tmp_name']) || ! file_exists($value['tmp_name']) || $value['error'] !== UPLOAD_ERR_OK) {
+            $this->success = false;
+        } else {
+            $this->success = true;
+        }
+
+        return $this->success;
+    }
+}

--- a/src/Rule/Upload/Size.php
+++ b/src/Rule/Upload/Size.php
@@ -32,8 +32,14 @@ class Size extends AbstractRule
     public function validate($value, $valueIdentifier = null)
     {
         $this->value = $value;
-        if (! is_array($value) || ! isset($value['tmp_name']) || ! file_exists($value['tmp_name'])) {
+        if (! is_array($value) || ! isset($value['tmp_name'])) {
             $this->success = false;
+        } else if(! file_exists($value['tmp_name'])) {
+            if($value['error'] === UPLOAD_ERR_NO_FILE ){
+                $this->success = true;
+            }else{
+                $this->success = false;
+            }
         } else {
             $fileSize      = @filesize($value['tmp_name']);
             $limit         = $this->normalizeSize($this->options[self::OPTION_SIZE]);

--- a/tests/src/Rule/Upload/ExtensionTest.php
+++ b/tests/src/Rule/Upload/ExtensionTest.php
@@ -24,6 +24,18 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->validator->validate($file));
     }
 
+    function testNoUpload()
+    {
+        $file     = array(
+            'name'     => 'not_required',
+            'type'     => 'not_required',
+            'size'     => 'not_required',
+            'tmp_name' => 'not_required',
+            'error'    => UPLOAD_ERR_NO_FILE
+        );
+        $this->assertTrue($this->validator->validate($file));
+    }
+
     function testMissingFiles()
     {
         $this->validator->setOption(Extension::OPTION_ALLOWED_EXTENSIONS, array( 'jpg' ));

--- a/tests/src/Rule/Upload/ImageRatioTest.php
+++ b/tests/src/Rule/Upload/ImageRatioTest.php
@@ -23,6 +23,18 @@ class ImageRatioTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->validate($file));
     }
 
+    function testNoUpload()
+    {
+        $file     = array(
+            'name'     => 'not_required',
+            'type'     => 'not_required',
+            'size'     => 'not_required',
+            'tmp_name' => 'not_required',
+            'error'    => UPLOAD_ERR_NO_FILE
+        );
+        $this->assertTrue($this->validator->validate($file));
+    }
+
     function testSquare()
     {
         $fileName = 'square_image.gif';

--- a/tests/src/Rule/Upload/ImageTest.php
+++ b/tests/src/Rule/Upload/ImageTest.php
@@ -23,6 +23,18 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->validate($file));
     }
 
+    function testNoUpload()
+    {
+        $file     = array(
+            'name'     => 'not_required',
+            'type'     => 'not_required',
+            'size'     => 'not_required',
+            'tmp_name' => 'not_required',
+            'error'    => UPLOAD_ERR_NO_FILE
+        );
+        $this->assertTrue($this->validator->validate($file));
+    }
+
     function testRealImage()
     {
         $this->validator->setOption(Extension::OPTION_ALLOWED_EXTENSIONS, array( 'jpg' ));

--- a/tests/src/Rule/Upload/ImageWidthTest.php
+++ b/tests/src/Rule/Upload/ImageWidthTest.php
@@ -23,6 +23,18 @@ class ImageWidthTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->validate($file));
     }
 
+    function testNoUpload()
+    {
+        $file     = array(
+            'name'     => 'not_required',
+            'type'     => 'not_required',
+            'size'     => 'not_required',
+            'tmp_name' => 'not_required',
+            'error'    => UPLOAD_ERR_NO_FILE
+        );
+        $this->assertTrue($this->validator->validate($file));
+    }
+
     function testFile()
     {
         $fileName = 'real_jpeg_file.jpg';

--- a/tests/src/Rule/Upload/RequiredTest.php
+++ b/tests/src/Rule/Upload/RequiredTest.php
@@ -1,13 +1,20 @@
 <?php
+/**
+ * Created by PhpStorm.
+ * User: Gumacs
+ * Date: 2017. 03. 07.
+ * Time: 16:05
+ */
 
 namespace Sirius\Validation\Rule\Upload;
 
-class ImageHeightTest extends \PHPUnit_Framework_TestCase
+
+class RequiredTest extends \PHPUnit_Framework_TestCase
 {
 
     function setUp()
     {
-        $this->validator = new ImageHeight(array( 'min' => 400 ));
+        $this->validator = new Required();
     }
 
     function testMissingFiles()
@@ -23,6 +30,32 @@ class ImageHeightTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->validate($file));
     }
 
+    function testUploadOk()
+    {
+        $fileName = 'real_jpeg_file.jpg';
+        $file     = array(
+            'name'     => $fileName,
+            'type'     => 'not_required',
+            'size'     => 'not_required',
+            'tmp_name' => realpath(__DIR__ . '/../../../fixitures/') . DIRECTORY_SEPARATOR . $fileName,
+            'error'    => UPLOAD_ERR_OK
+        );
+        $this->assertTrue($this->validator->validate($file));
+    }
+
+    function testUploadNotOk()
+    {
+        $fileName = 'real_jpeg_file.jpg';
+        $file     = array(
+            'name'     => $fileName,
+            'type'     => 'not_required',
+            'size'     => 'not_required',
+            'tmp_name' => realpath(__DIR__ . '/../../../fixitures/') . DIRECTORY_SEPARATOR . $fileName,
+            'error'    => UPLOAD_ERR_PARTIAL
+        );
+        $this->assertFalse($this->validator->validate($file));
+    }
+
     function testNoUpload()
     {
         $file     = array(
@@ -32,7 +65,7 @@ class ImageHeightTest extends \PHPUnit_Framework_TestCase
             'tmp_name' => 'not_required',
             'error'    => UPLOAD_ERR_NO_FILE
         );
-        $this->assertTrue($this->validator->validate($file));
+        $this->assertFalse($this->validator->validate($file));
     }
 
     function testFile()
@@ -46,20 +79,5 @@ class ImageHeightTest extends \PHPUnit_Framework_TestCase
             'error'    => UPLOAD_ERR_OK
         );
         $this->assertTrue($this->validator->validate($file));
-
-        $fileName = 'square_image.gif';
-        $file     = array(
-            'name'     => $fileName,
-            'type'     => 'not_required',
-            'size'     => 'not_required',
-            'tmp_name' => realpath(__DIR__ . '/../../../fixitures/') . DIRECTORY_SEPARATOR . $fileName,
-            'error'    => UPLOAD_ERR_OK
-        );
-        $this->assertFalse($this->validator->validate($file));
-
-        // change minimum
-        $this->validator->setOption(ImageHeight::OPTION_MIN, 200);
-        $this->assertTrue($this->validator->validate($file));
     }
-
 }

--- a/tests/src/Rule/Upload/SizeTest.php
+++ b/tests/src/Rule/Upload/SizeTest.php
@@ -23,6 +23,18 @@ class SizeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->validate($file));
     }
 
+    function testNoUpload()
+    {
+        $file     = array(
+            'name'     => 'not_required',
+            'type'     => 'not_required',
+            'size'     => 'not_required',
+            'tmp_name' => 'not_required',
+            'error'    => UPLOAD_ERR_NO_FILE
+        );
+        $this->assertTrue($this->validator->validate($file));
+    }
+
     function testFile()
     {
         $fileName = 'real_jpeg_file.jpg';


### PR DESCRIPTION
Fixed the problem where the uploaded file was always rejected even when had the UPLOAD_ERR_NO_FILE flag. It is changed accordingly, so now the Upload rules doesn't fail when there is no file uploaded. It only do so, if the Upload\Required rule is added. 

Added tests for the new rule and the old rules.

It even fixes the issue mentioned in the sirisphp/upload repository here:  [issue](https://github.com/siriusphp/upload/issues/12) (though it still need some adjusment to involve the new Upload\Required rule)