### PR TITLE
Fix issue #43

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
-  - '7'
 
 matrix:
     allow_failures:
@@ -22,8 +22,7 @@ before_script:
 script:
   - mkdir -p build/logs
   - composer run-script phpcs
-  - cd tests
-  - phpunit
+  - cd tests && ../vendor/bin/phpunit && cd ..
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/src/ValueValidator.php
+++ b/src/ValueValidator.php
@@ -242,15 +242,13 @@ class ValueValidator
         $this->messages = array();
         $isRequired     = false;
 
-        /* @var $rule \Sirius\Validation\Rule\AbstractValidator */
         // evaluate the required rules
+        /* @var $rule \Sirius\Validation\Rule\AbstractValidator */
         foreach ($this->rules as $rule) {
             if ($rule instanceof Rule\Required) {
                 $isRequired = true;
 
-                $rule->setContext($context);
-                if (!$rule->validate($value, $valueIdentifier)) {
-                    $this->addMessage($rule->getMessage());
+                if (!$this->validateRule($rule, $value, $valueIdentifier, $context)) {
                     return false;
                 }
             }
@@ -264,10 +262,8 @@ class ValueValidator
         // evaluate the non-required rules
         foreach ($this->rules as $rule) {
             if (!($rule instanceof Rule\Required)) {
-                $rule->setContext($context);
-                if (!$rule->validate($value, $valueIdentifier)) {
-                    $this->addMessage($rule->getMessage());
-                }
+                $this->validateRule($rule, $value, $valueIdentifier, $context);
+
                 // if field is required and we have an error,
                 // do not continue with the rest of rules
                 if ($isRequired && count($this->messages)) {
@@ -277,6 +273,16 @@ class ValueValidator
         }
 
         return count($this->messages) === 0;
+    }
+
+    private function validateRule($rule, $value, $valueIdentifier, $context)
+    {
+        $rule->setContext($context);
+        if (!$rule->validate($value, $valueIdentifier)) {
+            $this->addMessage($rule->getMessage());
+            return false;
+        }
+        return true;
     }
 
     public function getMessages()

--- a/tests/src/ValidatorTest.php
+++ b/tests/src/ValidatorTest.php
@@ -281,4 +281,12 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($this->validator->getMessages()));
     }
 
+    function testValidationRequireConditional()
+    {
+        $this->validator->add(array(
+            'a' => array( 'number', 'requiredWith(b)' ),
+            'b' => array( 'number', 'requiredWith(a)' )
+        ));
+        $this->assertTrue($this->validator->validate(array()));
+    }
 }


### PR DESCRIPTION
When evaluating to an optional required rule plus other rule (as shown in issue #43) the result of the other rule is evaluated when it shouldn't.
```php
$validator = new \Sirius\Validation\Validator();
$validator->add(
    [
        'latitude' => ['requiredWith(longitude)', 'number'],
        'longitude' => ['requiredWith(latitude)', 'number']
    ]
);

$result = $validator->validate([]);
var_dump($result); // Returns false
```
The above example returns true because `ValueValidator::validate` evaluate against `Rule\Number` and do not exit since the rule set is not required.

This PR includes a test in `tests/src/ValidatorTest.php`, rewrite of `ValueValidator::validate` and create the private method `ValueValidator::validateRule` to avoid code duplication.
