### PR TITLE
Fix issue #46

### DIFF
--- a/src/Rule/AbstractRule.php
+++ b/src/Rule/AbstractRule.php
@@ -90,7 +90,7 @@ abstract class AbstractRule
      */
     protected function normalizeOptions($options)
     {
-        if ('0' !== $options && ! $options) {
+        if (! $options) {
             return array();
         }
 
@@ -99,7 +99,7 @@ abstract class AbstractRule
         }
 
         $result = $options;
-        if (is_string($options) && '' !== $options) {
+        if ($options && is_string($options)) {
             $startChar = substr($options, 0, 1);
             if ($startChar == '{') {
                 $result = json_decode($options, true);
@@ -264,7 +264,7 @@ abstract class AbstractRule
         }
         if (! is_object($context) || ! $context instanceof WrapperInterface) {
             throw new \InvalidArgumentException(
-                'Validator context must be either an array or an instance
+                'Validator context must be either an array or an instance 
                 of Sirius\Validator\DataWrapper\WrapperInterface'
             );
         }

--- a/src/Rule/AbstractRule.php
+++ b/src/Rule/AbstractRule.php
@@ -90,6 +90,9 @@ abstract class AbstractRule
      */
     protected function normalizeOptions($options)
     {
+        if ('0' === $options && count($this->optionsIndexMap) > 0) {
+            $options = [$this->optionsIndexMap[0] => '0'];
+        }
         if (! $options) {
             return array();
         }
@@ -264,7 +267,7 @@ abstract class AbstractRule
         }
         if (! is_object($context) || ! $context instanceof WrapperInterface) {
             throw new \InvalidArgumentException(
-                'Validator context must be either an array or an instance 
+                'Validator context must be either an array or an instance
                 of Sirius\Validator\DataWrapper\WrapperInterface'
             );
         }

--- a/src/Rule/AbstractRule.php
+++ b/src/Rule/AbstractRule.php
@@ -90,7 +90,7 @@ abstract class AbstractRule
      */
     protected function normalizeOptions($options)
     {
-        if (! $options) {
+        if ('0' !== $options && ! $options) {
             return array();
         }
 
@@ -99,7 +99,7 @@ abstract class AbstractRule
         }
 
         $result = $options;
-        if ($options && is_string($options)) {
+        if (is_string($options) && '' !== $options) {
             $startChar = substr($options, 0, 1);
             if ($startChar == '{') {
                 $result = json_decode($options, true);
@@ -264,7 +264,7 @@ abstract class AbstractRule
         }
         if (! is_object($context) || ! $context instanceof WrapperInterface) {
             throw new \InvalidArgumentException(
-                'Validator context must be either an array or an instance 
+                'Validator context must be either an array or an instance
                 of Sirius\Validator\DataWrapper\WrapperInterface'
             );
         }

--- a/src/Rule/AbstractRule.php
+++ b/src/Rule/AbstractRule.php
@@ -91,7 +91,7 @@ abstract class AbstractRule
     protected function normalizeOptions($options)
     {
         if ('0' === $options && count($this->optionsIndexMap) > 0) {
-            $options = [$this->optionsIndexMap[0] => '0'];
+            $options = array($this->optionsIndexMap[0] => '0');
         }
         if (! $options) {
             return array();

--- a/src/Rule/Website.php
+++ b/src/Rule/Website.php
@@ -12,11 +12,11 @@ class Website extends AbstractRule
     {
         $this->value   = $value;
         $this->success = (substr($value, 0, 2) == '//')
-                         || (preg_match(static::WEBSITE_REGEX, $value) && filter_var(
-                             $value,
-                             FILTER_VALIDATE_URL,
-                             FILTER_FLAG_HOST_REQUIRED
-                         ));
+                        || (preg_match(static::WEBSITE_REGEX, $value) && filter_var(
+                            $value,
+                            FILTER_VALIDATE_URL,
+                            FILTER_FLAG_HOST_REQUIRED
+                        ));
 
         return $this->success;
     }

--- a/tests/src/Rule/GreaterThanTest.php
+++ b/tests/src/Rule/GreaterThanTest.php
@@ -12,6 +12,12 @@ class GreaterThanTest extends \PHPUnit_Framework_TestCase
         $this->rule = new Rule();
     }
 
+    function testDefaultOptions()
+    {
+        $this->assertNull($this->rule->getOption('min'));
+        $this->assertTrue($this->rule->getOption('inclusive'));
+    }
+
     function testExclusiveValidation()
     {
         $this->rule->setOption('inclusive', false);

--- a/tests/src/Rule/GreaterThanTest.php
+++ b/tests/src/Rule/GreaterThanTest.php
@@ -29,4 +29,11 @@ class GreaterThanTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue($this->rule->validate(0));
     }
+
+    function testConstructCvsFormatMinZeroAndInclusiveFalse()
+    {
+        $this->rule = new Rule('0,false');
+        $this->assertSame('0', $this->rule->getOption('min'));
+        $this->assertSame(false, $this->rule->getOption('inclusive'));
+    }
 }

--- a/tests/src/Rule/GreaterThanTest.php
+++ b/tests/src/Rule/GreaterThanTest.php
@@ -36,4 +36,10 @@ class GreaterThanTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('0', $this->rule->getOption('min'));
         $this->assertSame(false, $this->rule->getOption('inclusive'));
     }
+
+    function testConstructWithMinValueZeroQueryStringFormat()
+    {
+        $this->rule = new Rule('min=0');
+        $this->assertSame('0', $this->rule->getOption('min'));
+    }
 }

--- a/tests/src/Rule/GreaterThanTest.php
+++ b/tests/src/Rule/GreaterThanTest.php
@@ -42,4 +42,10 @@ class GreaterThanTest extends \PHPUnit_Framework_TestCase
         $this->rule = new Rule('min=0');
         $this->assertSame('0', $this->rule->getOption('min'));
     }
+
+    function testConstructWithMinValueZeroCvsFormat()
+    {
+        $this->rule = new Rule('0');
+        $this->assertSame('0', $this->rule->getOption('min'));
+    }
 }


### PR DESCRIPTION
The issue #46 is reproducible for any rule that:
1. extends `AbstractRule`
2. set the options using cvs syntax with only one parameter that casting to boolean returns `false`, specifically `'0'`

A workaround could be just use another notation, like `'min=0'` or `'{"min":0}'`

But well, this fix prevents options to be rejected if the option is `'0'` **and** the rule has `$optionsIndexMap` declared and with a count greater than zero. In this special case then change the value of the options to the array of the first index of `$optionsIndexMap` as key and `'0'` as value.