### PR TITLE
fix checking empty value as strict

### DIFF
--- a/src/ValueValidator.php
+++ b/src/ValueValidator.php
@@ -304,6 +304,6 @@ class ValueValidator
 
     protected function isEmpty($value)
     {
-        return in_array($value, array(null, ''));
+        return in_array($value, array(null, ''), true);
     }
 }


### PR DESCRIPTION
Example:
```
->add('storeId', GreaterThan::class, ['min' => 0, 'inclusive' => false]
```
validator never starts when value is 0 because method isEmpty(ValueValidator.php) returns true